### PR TITLE
Possible Bug Fix: Default mock revolvers are not re initialized after each test run. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const merge = require('lodash/merge')
 
 function setupClient(mockResolvers, typeDefs) {
   return function createClient(overwriteMocks = {}) {
-    const mergedMocks = merge(mockResolvers, overwriteMocks)
+    const mergedMocks = merge({...mockResolvers}, overwriteMocks)
 
     const schema = makeExecutableSchema({ typeDefs })
     addMockFunctionsToSchema({


### PR DESCRIPTION
Pass lodash.merge a shallow copy of mockResolvers instead of passing it directly.